### PR TITLE
Get the URL and the Regexp of the public IP web page from the config file

### DIFF
--- a/IpWatchDog.sln
+++ b/IpWatchDog.sln
@@ -1,16 +1,24 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpWatchDog", "IpWatchDog\IpWatchDog.csproj", "{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Debug|x86.ActiveCfg = Debug|x86
 		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Debug|x86.Build.0 = Debug|x86
+		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Release|x86.ActiveCfg = Release|x86
 		{0A20C9D6-E6BB-40F4-A166-56B8612FECAA}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/IpWatchDog/App.config
+++ b/IpWatchDog/App.config
@@ -1,17 +1,20 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <configuration>
   <appSettings>
-    <add key="PollingTimeoutSeconds" value="900"/>
-
+    <add key="PollingTimeoutSeconds" value="900" />
     <!-- use parameters below to send notification e-mail -->
-    <add key="MailFrom" value="change-ip@example.com"/>
-    <add key="MailTo" value="user@example.com"/>
-    <add key="Subject" value="IP changed"/>
-    <add key="SmtpHost" value="mail.example.com"/>
-    
+    <add key="MailFrom" value="change-ip@example.com" />
+    <add key="MailTo" value="user@example.com" />
+    <add key="Subject" value="IP changed" />
+    <add key="SmtpHost" value="mail.example.com" />
+    <add key="IPChecker" value="http://checkip.dyndns.org/" />
+    <add key="IPCheckerRegExp" value="\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b" />
     <!-- or specify command to be executed -->
     <!--
     <add key="Command" value="echo &quot;IP changed from ${old} to ${new}&quot; &gt; c:\temp\change.txt" />
     -->
   </appSettings>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+</configuration>

--- a/IpWatchDog/App.config
+++ b/IpWatchDog/App.config
@@ -7,6 +7,12 @@
     <add key="MailTo" value="user@example.com" />
     <add key="Subject" value="IP changed" />
     <add key="SmtpHost" value="mail.example.com" />
+    <add key="SmtpPort" value="25" />
+    <!-- Authentication values for email sending -->
+    <add key="SmtpUserName" value="change-ip@example.com" />
+    <add key="SmtpPassword" value="*********" />
+    <!-- true or false. true if the SMTP server requires SSL conenction (SMTPS on port 465 or Google on 587).  -->
+    <add key="SmtpUseSsl" value="false" />
     <add key="IPChecker" value="https://www.cloudflare.com/cdn-cgi/trace" />
     <add key="IPCheckerRegExp" value="\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b" />
     <!-- or specify command to be executed -->

--- a/IpWatchDog/App.config
+++ b/IpWatchDog/App.config
@@ -7,7 +7,7 @@
     <add key="MailTo" value="user@example.com" />
     <add key="Subject" value="IP changed" />
     <add key="SmtpHost" value="mail.example.com" />
-    <add key="IPChecker" value="http://checkip.dyndns.org/" />
+    <add key="IPChecker" value="https://www.cloudflare.com/cdn-cgi/trace" />
     <add key="IPCheckerRegExp" value="\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b" />
     <!-- or specify command to be executed -->
     <!--

--- a/IpWatchDog/AppConfig.cs
+++ b/IpWatchDog/AppConfig.cs
@@ -1,41 +1,26 @@
-﻿using System;
-using System.Configuration;
+﻿using System.Configuration;
 
 namespace IpWatchDog
 {
     class AppConfig
     {
-        public int PollingTimeoutSeconds
-        {
-            get { return Int32.Parse(Config("PollingTimeoutSeconds")); }
-        }
+        public int PollingTimeoutSeconds => int.Parse(Config("PollingTimeoutSeconds"));
 
-        public string MailFrom
-        {
-            get { return Config("MailFrom"); }
-        }
+        public string MailFrom => Config("MailFrom");
 
-        public string MailTo
-        {
-            get { return Config("MailTo"); }
-        }
+        public string MailTo => Config("MailTo");
 
-        public string SmtpHost
-        {
-            get { return Config("SmtpHost"); }
-        }
+        public string SmtpHost => Config("SmtpHost");
 
-        public string Subject
-        {
-            get { return Config("Subject"); }
-        }
+        public string Subject => Config("Subject");
 
-        public string Command
-        {
-            get { return Config("Command"); }
-        }
+        public string Command => Config("Command");
 
-        private string Config(string arg)
+        public string IPChecker => Config("IPChecker");
+
+        public string IPCheckerRegExp => Config("IPCheckerRegExp");
+
+        private static string Config(string arg)
         {
             return ConfigurationManager.AppSettings[arg];
         }

--- a/IpWatchDog/AppConfig.cs
+++ b/IpWatchDog/AppConfig.cs
@@ -12,6 +12,14 @@ namespace IpWatchDog
 
         public string SmtpHost => Config("SmtpHost");
 
+        public int SmtpPort => int.Parse(Config("SmtpPort"));
+
+        public string SmtpUserName => Config("SmtpUserName");
+
+        public string SmtpPassword => Config("SmtpPassword");
+
+        public bool SmtpUseSsl => bool.Parse(Config("SmtpUseSsl"));
+
         public string Subject => Config("Subject");
 
         public string Command => Config("Command");

--- a/IpWatchDog/CommandIpNotifier.cs
+++ b/IpWatchDog/CommandIpNotifier.cs
@@ -5,16 +5,16 @@ using System.IO;
 
 namespace IpWatchDog
 {
-    class CommandIpNotifier : IIpNotifier
+    internal class CommandIpNotifier : IIpNotifier
     {
-        string _command;
-        ILog _log;
+        private readonly string _command;
+        private readonly ILog _log;
 
         public CommandIpNotifier(ILog log, AppConfig config)
         {
             _log = log;
             _command = config.Command.Trim();
-            if (String.IsNullOrEmpty(_command))
+            if (string.IsNullOrEmpty(_command))
             {
                 throw new ArgumentException("Command cannot be null or empty");
             }

--- a/IpWatchDog/Configurator.cs
+++ b/IpWatchDog/Configurator.cs
@@ -4,10 +4,10 @@ using IpWatchDog.Runners;
 
 namespace IpWatchDog
 {
-    class Configurator
+    internal class Configurator
     {
-        private ILog _log;
-        private bool _isConsole;
+        private readonly ILog _log;
+        private readonly bool _isConsole;
 
         public Configurator(bool isConsole)
         {
@@ -45,7 +45,7 @@ namespace IpWatchDog
                 _log, 
                 config,
                 new IpPersistor(_log), 
-                new WebIpRetriever(_log), 
+                new WebIpRetriever(_log, config), 
                 notifier);
         }
 
@@ -55,10 +55,7 @@ namespace IpWatchDog
             {
                 return new MailIpNotifier(_log, config);
             }
-            else
-            {
-                return new CommandIpNotifier(_log, config);
-            }
+            return new CommandIpNotifier(_log, config);
         }
     }
 }

--- a/IpWatchDog/HttpWebResponseExt.cs
+++ b/IpWatchDog/HttpWebResponseExt.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+
+namespace IpWatchDog
+{
+    internal static class HttpWebResponseExt
+    {
+        public static HttpWebResponse GetResponseNoException(this HttpWebRequest req)
+        {
+            try
+            {
+                return (HttpWebResponse)req.GetResponse();
+            }
+            catch (WebException we)
+            {
+                var resp = we.Response as HttpWebResponse;
+                if (resp == null)
+                    throw;
+                return resp;
+            }
+        }
+    }
+}

--- a/IpWatchDog/IIpNotifier.cs
+++ b/IpWatchDog/IIpNotifier.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog
 {
-    interface IIpNotifier
+    internal interface IIpNotifier
     {
         void OnIpChanged(string oldIp, string newIp);
     }

--- a/IpWatchDog/IIpPersistor.cs
+++ b/IpWatchDog/IIpPersistor.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog
 {
-    interface IIpPersistor : IIpRetriever
+    internal interface IIpPersistor : IIpRetriever
     {
         void SaveIp(string ip);
     }

--- a/IpWatchDog/IIpRetriever.cs
+++ b/IpWatchDog/IIpRetriever.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog
 {
-    interface IIpRetriever
+    internal interface IIpRetriever
     {
         string GetIp();
     }

--- a/IpWatchDog/IService.cs
+++ b/IpWatchDog/IService.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog
 {
-    interface IService
+    internal interface IService
     {
         void Start();
         void Stop();

--- a/IpWatchDog/Install/InstallUtil.cs
+++ b/IpWatchDog/Install/InstallUtil.cs
@@ -5,9 +5,9 @@ using IpWatchDog.Log;
 
 namespace IpWatchDog.Install
 {
-    class InstallUtil
+    internal class InstallUtil
     {
-        ILog _log;
+        private readonly ILog _log;
 
         public InstallUtil(ILog log)
         {

--- a/IpWatchDog/IpPersistor.cs
+++ b/IpWatchDog/IpPersistor.cs
@@ -4,10 +4,10 @@ using IpWatchDog.Log;
 
 namespace IpWatchDog
 {
-    class IpPersistor : IIpPersistor
+    internal class IpPersistor : IIpPersistor
     {
-        private string _path;
-        private ILog _log;
+        private readonly string _path;
+        private readonly ILog _log;
 
         public IpPersistor(ILog log)
         {

--- a/IpWatchDog/IpWatchDog.csproj
+++ b/IpWatchDog/IpWatchDog.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IpWatchDog</RootNamespace>
     <AssemblyName>IpWatchDog</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -32,9 +33,28 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -43,12 +63,14 @@
     <Reference Include="System.Management" />
     <Reference Include="System.Data" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppConfig.cs" />
     <Compile Include="CommandIpNotifier.cs" />
     <Compile Include="Configurator.cs" />
+    <Compile Include="HttpWebResponseExt.cs" />
     <Compile Include="IIpNotifier.cs" />
     <Compile Include="IIpPersistor.cs" />
     <Compile Include="IIpRetriever.cs" />

--- a/IpWatchDog/IpWatchDogService.cs
+++ b/IpWatchDog/IpWatchDogService.cs
@@ -3,18 +3,18 @@ using IpWatchDog.Log;
 
 namespace IpWatchDog
 {
-    class IpWatchDogService : IService
+    internal class IpWatchDogService : IService
     {
-        IIpPersistor _persistor;
-        IIpRetriever _retriever;
-        IIpNotifier _notifier;
-        AppConfig _config;
+        private readonly IIpPersistor _persistor;
+        private readonly IIpRetriever _retriever;
+        private readonly IIpNotifier _notifier;
+        private readonly AppConfig _config;
 
-        Timer _timer;
-        object _isBusy = new object();
-        bool _stopRequested;
-        ILog _log;
-        string _currentIp;
+        private Timer _timer;
+        private readonly object _isBusy = new object();
+        private bool _stopRequested;
+        private readonly ILog _log;
+        private string _currentIp;
 
         public IpWatchDogService(ILog log, AppConfig config, IIpPersistor persistor, IIpRetriever retriever, IIpNotifier notifier)
         {

--- a/IpWatchDog/Log/ConsoleLog.cs
+++ b/IpWatchDog/Log/ConsoleLog.cs
@@ -2,7 +2,7 @@
 
 namespace IpWatchDog.Log
 {
-    class ConsoleLog : ILog
+    internal class ConsoleLog : ILog
     {
         public void Write(LogLevel level, string format, params object[] args)
         {

--- a/IpWatchDog/Log/ILog.cs
+++ b/IpWatchDog/Log/ILog.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog.Log
 {
-    interface ILog
+    internal interface ILog
     {
         void Write(LogLevel level, string format, params object[] args);
     }

--- a/IpWatchDog/Log/LogLevel.cs
+++ b/IpWatchDog/Log/LogLevel.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog.Log
 {
-    enum LogLevel
+    internal enum LogLevel
     {
         Debug,
         Info,

--- a/IpWatchDog/Log/SystemLog.cs
+++ b/IpWatchDog/Log/SystemLog.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace IpWatchDog.Log
 {
-    class SystemLog : ILog
+    internal class SystemLog : ILog
     {
-        private EventLog _eventLog;
+        private readonly EventLog _eventLog;
 
         public SystemLog(string eventSourceName)
         {
@@ -21,7 +20,7 @@ namespace IpWatchDog.Log
         public void Write(LogLevel level, string format, params object[] args)
         {
             if (_eventLog == null) return;
-            var message = String.Format(format, args);
+            var message = string.Format(format, args);
             _eventLog.WriteEntry(message, ToEntryType(level));
         }
 

--- a/IpWatchDog/MailIpNotifier.cs
+++ b/IpWatchDog/MailIpNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Mail;
 using IpWatchDog.Log;
 
@@ -22,11 +23,16 @@ namespace IpWatchDog
 
             try
             {
-                var smtpClient = new SmtpClient(_config.SmtpHost);
+                var smtpClient = new SmtpClient(_config.SmtpHost, _config.SmtpPort) {EnableSsl = _config.SmtpUseSsl, DeliveryMethod = SmtpDeliveryMethod.Network };
+                if (_config.SmtpUserName != string.Empty)
+                {
+                    smtpClient.UseDefaultCredentials = false;
+                    smtpClient.Credentials = new NetworkCredential(_config.SmtpUserName, _config.SmtpPassword);
+                }
                 smtpClient.Send(
                     _config.MailFrom,
                     _config.MailTo,
-                    "IP change",
+                    _config.Subject,
                     msg);
             }
             catch (Exception ex)

--- a/IpWatchDog/MailIpNotifier.cs
+++ b/IpWatchDog/MailIpNotifier.cs
@@ -4,10 +4,10 @@ using IpWatchDog.Log;
 
 namespace IpWatchDog
 {
-    class MailIpNotifier : IIpNotifier
+    internal class MailIpNotifier : IIpNotifier
     {
-        ILog _log;
-        AppConfig _config;
+        private readonly ILog _log;
+        private readonly AppConfig _config;
 
         public MailIpNotifier(ILog log, AppConfig config)
         {
@@ -17,7 +17,7 @@ namespace IpWatchDog
 
         public void OnIpChanged(string oldIp, string newIp)
         {
-            string msg = GetMessage(oldIp, newIp);
+            var msg = GetMessage(oldIp, newIp);
             _log.Write(LogLevel.Warning, msg);
 
             try
@@ -37,7 +37,7 @@ namespace IpWatchDog
 
         private static string GetMessage(string oldIp, string newIp)
         {
-            return String.Format("IP changed from {0} to {1}", oldIp, newIp);
+            return $"IP changed from {oldIp} to {newIp}";
         }
     }
 }

--- a/IpWatchDog/Program.cs
+++ b/IpWatchDog/Program.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.ServiceProcess;
-using IpWatchDog.Runners;
-using IpWatchDog.Log;
-using IpWatchDog.Install;
 
 namespace IpWatchDog
 {
-    static class Program
+    public static class Program
     {
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             if (args.Length == 0)
             {

--- a/IpWatchDog/Runners/ConsoleRunner.cs
+++ b/IpWatchDog/Runners/ConsoleRunner.cs
@@ -3,17 +3,17 @@ using System.Threading;
 
 namespace IpWatchDog.Runners
 {
-    class ConsoleRunner : IRunner
+    internal class ConsoleRunner : IRunner
     {
-        private IService _service;
+        private readonly IService _service;
         private bool _isRunning;
-        private object _monitor = new object();
+        private readonly object _monitor = new object();
 
         public ConsoleRunner(IService service)
         {
             if (service == null) throw new ArgumentNullException("service");
             _service = service;
-            Console.CancelKeyPress += new ConsoleCancelEventHandler(OnCancel);
+            Console.CancelKeyPress += OnCancel;
         }
 
         public void Run()
@@ -28,7 +28,7 @@ namespace IpWatchDog.Runners
             }
         }
 
-        void OnCancel(object sender, ConsoleCancelEventArgs e)
+        private void OnCancel(object sender, ConsoleCancelEventArgs e)
         {
             if (!_isRunning) return;
 

--- a/IpWatchDog/Runners/IRunner.cs
+++ b/IpWatchDog/Runners/IRunner.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog.Runners
 {
-    interface IRunner
+    internal interface IRunner
     {
         void Run();
     }

--- a/IpWatchDog/Runners/ServiceRunner.cs
+++ b/IpWatchDog/Runners/ServiceRunner.cs
@@ -3,9 +3,9 @@ using System.ServiceProcess;
 
 namespace IpWatchDog.Runners
 {
-    class ServiceRunner : ServiceBase, IRunner
+    internal class ServiceRunner : ServiceBase, IRunner
     {
-        IService _service;
+        readonly IService _service;
 
         public ServiceRunner(IService service, string serviceName)
         {

--- a/IpWatchDog/ServiceController.cs
+++ b/IpWatchDog/ServiceController.cs
@@ -4,10 +4,10 @@ using IpWatchDog.Log;
 
 namespace IpWatchDog
 {
-    class ServiceController : IService
+    internal class ServiceController : IService
     {
-        System.ServiceProcess.ServiceController _controller;
-        ILog _log;
+        private readonly System.ServiceProcess.ServiceController _controller;
+        private readonly ILog _log;
 
         public ServiceController(ILog log)
         {
@@ -23,7 +23,7 @@ namespace IpWatchDog
                 const int timeout = 10000;
                 _controller.Start();
 
-                var targetStatus = ServiceControllerStatus.Running;
+                const ServiceControllerStatus targetStatus = ServiceControllerStatus.Running;
                 _controller.WaitForStatus(targetStatus, TimeSpan.FromMilliseconds(timeout));
 
                 if (_controller.Status == targetStatus)
@@ -49,7 +49,7 @@ namespace IpWatchDog
                 const int timeout = 10000;
                 _controller.Stop();
 
-                var targetStatus = ServiceControllerStatus.Stopped;
+                const ServiceControllerStatus targetStatus = ServiceControllerStatus.Stopped;
                 _controller.WaitForStatus(targetStatus, TimeSpan.FromMilliseconds(timeout));
 
                 if (_controller.Status == targetStatus)

--- a/IpWatchDog/StringConstants.cs
+++ b/IpWatchDog/StringConstants.cs
@@ -1,6 +1,6 @@
 ﻿namespace IpWatchDog
 {
-    class StringConstants
+    internal class StringConstants
     {
         public const string ServiceName = "IpWatchDog";
         public const string ServiceDisplayName = "IP Watchdog";

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,10 @@
 This is an IP watchdog service.
 
 Its job is to monitor local computer's external IP address
-(obtained via checkip.dyndns.org) and send e-mail notification
+(obtained via different public IP provider) and send e-mail notification
 when it changes.
+
+If you try to run the service, please copy the files to the 
+Program Files folder first, because it runs under Network Service account,
+and Network Service account doesn't have rights to open or execute files
+from other users' home folder.


### PR DESCRIPTION
- Get the URL and the Regexp of the public IP web page from the config file
- Added some "internal" to class definition and readonly to the private variable
- Changed to .Net 4.6.1
- Read only the first 4096 byte from the http response
- http response errors handled more accuracy
- Changed checkip to Cloudflare's trace page. It is faster.
- Added option to send email on configurable port with username and password (and with SSL)
